### PR TITLE
[Bootstrap]: Default to `main` branch when pulling archive

### DIFF
--- a/README.org
+++ b/README.org
@@ -6,7 +6,7 @@ On macOS, run the following as the administrative user.
 On Linux, run the following as root, reboot, and run again as the sudo user.
 
 #+begin_src bash
-bash -c "$(wget -qO - https://raw.github.com/montchr/dots/feature/dotbot/bootstrap)"
+bash -c "$(wget -qO - https://raw.github.com/montchr/dots/main/bootstrap)"
 #+end_src
 
 ** Bootstrap
@@ -17,13 +17,14 @@ First, set ~CDOM_INIT_INTERACTIVE=false~.
 
 Then set the following values:
 
-| Name                          | Description                             |
-|-------------------------------+-----------------------------------------|
-| ~CDOM_INIT_NEW_USER_NAME~     | Name of the new sudo user to be created |
-| ~CDOM_INIT_NEW_USER_PASSWORD~ | Password for the new user               |
-| ~CDOM_INIT_PUBKEY~            | SSH public key for the new user         |
-| ~CDOM_INIT_TIMEZONE~          | System timezone                         |
-| ~CDOM_INIT_HOSTNAME~          | System hostname                         |
+| Name                          | Description                                 | Default             |
+|-------------------------------+---------------------------------------------+---------------------|
+| ~CDOM_INIT_DOTFILES_BRANCH~   | Branch from which dotfiles should be pulled | ~main~              |
+| ~CDOM_INIT_HOSTNAME~          | System hostname                             | ~CDOM~              |
+| ~CDOM_INIT_NEW_USER_NAME~     | Name of the new sudo user to be created     |                     |
+| ~CDOM_INIT_NEW_USER_PASSWORD~ | Password for the new user                   |                     |
+| ~CDOM_INIT_PUBKEY~            | SSH public key for the new user             |                     |
+| ~CDOM_INIT_TIMEZONE~          | System timezone                             | ~America/New_York~  |
 
 
 * Thank Yous + References

--- a/bootstrap
+++ b/bootstrap
@@ -4,7 +4,7 @@ set -e
 
 readonly GITHUB_REPOSITORY="montchr/dots"
 readonly DOTFILES_ORIGIN="git@github.com:$GITHUB_REPOSITORY.git"
-readonly DOTFILES_BRANCH="feature/dotbot"
+readonly DOTFILES_BRANCH="${CDOM_INIT_DOTFILES_BRANCH:-main}"
 readonly DOTFILES_TARBALL_URL="https://github.com/$GITHUB_REPOSITORY/tarball/${DOTFILES_BRANCH}"
 readonly DOTFILES_UTILS_URL="https://raw.githubusercontent.com/$GITHUB_REPOSITORY/${DOTFILES_BRANCH}/lib/utils.sh"
 DOTFILES_DIR="${HOME}/.dots"

--- a/bootstrap
+++ b/bootstrap
@@ -225,11 +225,11 @@ function main () {
   # shellcheck disable=SC1090
   print_hed "OS Essentials" \
     && . "os/$(get_os)/install" \
-    && print_result $? "\nOS Essentials"
+    && print_result $? "OS Essentials"
 
   print_hed "OS Preferences" \
     && .do_configure \
-    && print_result $? "\nOS Preferences"
+    && print_result $? "OS Preferences"
 
   # Initialize the dotfiles directory as a git repo for a non-root user.
   if [[ "root" != $(whoami) ]] && ! is_git_repository; then

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -59,6 +59,13 @@ function print_subhed () {
   print_in_green "\n   $1\n"
 }
 
+# Print a basic informational message.
+# Parameters:
+#   Message
+function print_info() {
+  print_in_purple "\n   $1\n"
+}
+
 # Prompt the user for a response to a question.
 # Parameters:
 #   Message

--- a/os/ubuntu/install
+++ b/os/ubuntu/install
@@ -15,7 +15,7 @@ function .cleanup () {
   sudo service ssh restart
 
   [[ -f "/etc/sudoers.bak" ]] && {
-    print_in_purple "Restoring original /etc/sudoers file..."
+    print_info "Restoring original /etc/sudoers file..."
     sudo mv /etc/sudoers.bak /etc/sudoers
   }
 }


### PR DESCRIPTION
- Fixes old references to `feature/dotbot`
- Fixes incorrect linebreaks in `./bootstrap` output
- Adds `print_info()` Bash utility function